### PR TITLE
URL dinâmica , mais  de uma loja para mesma conta cielo

### DIFF
--- a/includes/class-wc-checkout-cielo-api.php
+++ b/includes/class-wc-checkout-cielo-api.php
@@ -319,7 +319,8 @@ class WC_Checkout_Cielo_API {
 		$data = array(
 			'merchant_id'       => $this->merchant_id,
 			'order_number'      => $order->id,
-			'antifraud_enabled' => ( 'yes' == $this->antifraud ) ? 'TRUE' : 'FALSE'
+			'antifraud_enabled' => ( 'yes' == $this->antifraud ) ? 'TRUE' : 'FALSE',
+			'ReturnUrl' => 'false'
 		);
 
 		$customer_data = $this->get_customer_data( $order );


### PR DESCRIPTION
adicionei a linha
'ReturnUrl' => 'false' para passar a url personalizada caso  use a mesma conta cielo para várias lojas virtuais .

na conta principal pode deixar false e nas demais colocar a url que deseja retornar , ou seja a url da loja atual;

exemplo:
'ReturnUrl' => 'http://loja2.com.br'